### PR TITLE
Initialize FastAPI project with ping endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Instructions
+
+## Installation
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Lint
+
+```bash
+ruff check .
+```
+
+## Test
+
+```bash
+pytest -q
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fastapi-app"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi",
+    "uvicorn"
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "ruff", "httpx"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/ping")
+def ping():
+    return {"status": "ok"}

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_ping():
+    client = TestClient(app)
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- Set up FastAPI application with /ping healthcheck
- Configure project and developer tooling
- Add pytest suite for ping endpoint

## Testing
- `pip install -e ".[dev]"`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891134c39a4832c8d6ccfc6cca73fc3